### PR TITLE
recent webcamp talks added, typo fixed

### DIFF
--- a/_data/resources/catztalks.yml
+++ b/_data/resources/catztalks.yml
@@ -20,6 +20,12 @@ links:
   - title: "Mateja Verlič: Nevidnost (TEDxLjubljana)"
     date: 2014-11-16
     url: https://www.youtube.com/watch?v=i-ZEN4nFhuo
-  - title: "Alja Isaković: Ne le všečaj, ustvarjaj! (TEDxCelje)"
+  - title: "Alja Isaković: Ne le všečkaj, ustvarjaj! (TEDxCelje)"
     date: 2013-06-01
     url: https://www.youtube.com/watch?v=0GX1DdLyJGs
+  - title: "Alja Isaković: Git your Jekyll on and build a magic static blog or landing page (WebCamp Ljubljana)"
+    date: 2015-03-20
+    url: http://video.webcamp.si/wc2015_isakovic_git_your_jekyll/
+  - title: "Maša Černovšek Logar : An architect's approach to building webs (WebCamp Ljubljana)"
+    date: 2015-03-20
+    url: http://video.webcamp.si/wc2015_logar_approach_to_building_webs/

--- a/_data/resources/catztalks.yml
+++ b/_data/resources/catztalks.yml
@@ -26,6 +26,6 @@ links:
   - title: "Alja Isaković: Git your Jekyll on and build a magic static blog or landing page (WebCamp Ljubljana)"
     date: 2015-03-20
     url: http://video.webcamp.si/wc2015_isakovic_git_your_jekyll/
-  - title: "Maša Černovšek Logar : An architect's approach to building webs (WebCamp Ljubljana)"
+  - title: "Maša Černovšek Logar: An architect's approach to building webs (WebCamp Ljubljana)"
     date: 2015-03-20
     url: http://video.webcamp.si/wc2015_logar_approach_to_building_webs/


### PR DESCRIPTION
Added links to WebCamp talks by Maša and Alja, fixed typo in one of previous talk titles.